### PR TITLE
Fix problem with modern Jackson and error handling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
           java-version: |
             21
             17
+            8
       - name: savant setup
         run: |
           curl -O https://repository.savantbuild.org/org/savantbuild/savant-core/2.2.0/savant-2.2.0.tar.gz
@@ -27,11 +28,12 @@ jobs:
           savant-2.2.0/bin/sb --version
           SAVANT_PATH=$(realpath -s "./savant-2.2.0/bin")
           echo "${SAVANT_PATH}" >> $GITHUB_PATH
+          
           mkdir -p ~/.savant/plugins
-          # For now, using the JDK that comes on the GHA runner
           cat << EOF > ~/.savant/plugins/org.savantbuild.plugin.java.properties
           17=${JAVA_HOME_17_X64}
           21=${JAVA_HOME_21_X64}
+          1.8=${JAVA_HOME_8_X64}
           EOF
           echo "~/.savant/plugins/org.savantbuild.plugin.java.properties"
           cat ~/.savant/plugins/org.savantbuild.plugin.java.properties

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,10 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
+          # we need to compile with 8, but make 21 the default we run savant with by virtue of it being last
           java-version: |
-            21
-            17
             8
+            21
       - name: savant setup
         run: |
           curl -O https://repository.savantbuild.org/org/savantbuild/savant-core/2.2.0/savant-2.2.0.tar.gz
@@ -31,7 +31,6 @@ jobs:
           
           mkdir -p ~/.savant/plugins
           cat << EOF > ~/.savant/plugins/org.savantbuild.plugin.java.properties
-          17=${JAVA_HOME_17_X64}
           21=${JAVA_HOME_21_X64}
           1.8=${JAVA_HOME_8_X64}
           EOF

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,52 @@
+---
+name: build
+
+on:
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        shell: /usr/bin/bash -l -e -o pipefail {0}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v6
+      - name: setup java
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: |
+            21
+            17
+      - name: savant setup
+        run: |
+          curl -O https://repository.savantbuild.org/org/savantbuild/savant-core/2.2.0/savant-2.2.0.tar.gz
+          tar xzvf savant-2.2.0.tar.gz
+          savant-2.2.0/bin/sb --version
+          SAVANT_PATH=$(realpath -s "./savant-2.2.0/bin")
+          echo "${SAVANT_PATH}" >> $GITHUB_PATH
+          mkdir -p ~/.savant/plugins
+          # For now, using the JDK that comes on the GHA runner
+          cat << EOF > ~/.savant/plugins/org.savantbuild.plugin.java.properties
+          17=${JAVA_HOME_17_X64}
+          21=${JAVA_HOME_21_X64}
+          EOF
+          echo "~/.savant/plugins/org.savantbuild.plugin.java.properties"
+          cat ~/.savant/plugins/org.savantbuild.plugin.java.properties
+      # Takes some time, better to tell difference between this step and actual test run time
+      - name: compile/pull Savant dependencies
+        run: |
+          $JAVA_HOME/bin/java -version
+          sb --version
+          sb clean compile
+      - name: run tests/integrate
+        run: |
+          sb clean int
+      - name: capture reports
+        uses: actions/upload-artifact@v6
+        if: success() || failure() # always run even if the previous step fails
+        with:
+          name: testng_reports
+          path: build/test-reports/

--- a/build.savant
+++ b/build.savant
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2026, Inversoft Inc., All Rights Reserved
  */
-jacksonVersion = "2.21.1"
+jacksonVersion = "2.21.4"
 jacksonAnnotationsVersion = "2.21"  // No 2.21.1 version available at time of update, maybe we can reunite the versions later
 testngVersion = "7.3.0"
 

--- a/build.savant
+++ b/build.savant
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2015-2025, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2015-2026, Inversoft Inc., All Rights Reserved
  */
-jacksonVersion = "2.15.4"
+jacksonVersion = "2.21.1"
+jacksonAnnotationsVersion = "2.21"  // No 2.21.1 version available at time of update, maybe we can reunite the versions later
 testngVersion = "7.3.0"
 
-project(group: "com.inversoft", name: "jackson5", version: "3.0.1", licenses: ["ApacheV2_0"]) {
+project(group: "com.inversoft", name: "jackson5", version: "3.1.0", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       cache()
@@ -24,7 +25,7 @@ project(group: "com.inversoft", name: "jackson5", version: "3.0.1", licenses: ["
     group(name: "compile") {
       dependency(id: "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}")
       dependency(id: "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}")
-      dependency(id: "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}")
+      dependency(id: "com.fasterxml.jackson.core:jackson-annotations:${jacksonAnnotationsVersion}")
     }
     group(name: "test-compile", export: false) {
       dependency(id: "org.testng:testng:${testngVersion}")

--- a/jackson5.iml
+++ b/jackson5.iml
@@ -15,11 +15,11 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.21.1/jackson-databind-2.21.1.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.21.4/jackson-databind-2.21.4.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.21.1/jackson-databind-2.21.1-sources.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.21.4/jackson-databind-2.21.4-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
@@ -37,11 +37,11 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.21.1/jackson-core-2.21.1.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.21.4/jackson-core-2.21.4.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.21.1/jackson-core-2.21.1-sources.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.21.4/jackson-core-2.21.4-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>

--- a/jackson5.iml
+++ b/jackson5.iml
@@ -15,77 +15,207 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/fasterxml/jackson/core/jackson-databind/2.15.4/jackson-databind-2.15.4.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.15.4/jackson-databind-2.15.4.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/fasterxml/jackson/core/jackson-databind/2.15.4/jackson-databind-2.15.4-src.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.15.4/jackson-databind-2.15.4-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/fasterxml/jackson/core/jackson-annotations/2.15.4/jackson-annotations-2.15.4.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.15.4/jackson-annotations-2.15.4.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/fasterxml/jackson/core/jackson-annotations/2.15.4/jackson-annotations-2.15.4-src.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.15.4/jackson-annotations-2.15.4-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/fasterxml/jackson/core/jackson-core/2.15.4/jackson-core-2.15.4.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.15.4/jackson-core-2.15.4.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/fasterxml/jackson/core/jackson-core/2.15.4/jackson-core-2.15.4-src.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.15.4/jackson-core-2.15.4-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/testng/testng/7.8.0/testng-7.8.0.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/org/testng/testng/7.3.0/testng-7.3.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/testng/testng/7.8.0/testng-7.8.0-src.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/org/testng/testng/7.3.0/testng-7.3.0-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/com/beust/jcommander/1.78.0/jcommander-1.78.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36-src.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/com/beust/jcommander/1.78.0/jcommander-1.78.0-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/beust/jcommander/1.82.0/jcommander-1.82.0.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/com/google/inject/guice/4.2.2/guice-no_aop-4.2.2.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="TEST">
+      <library>
+        <CLASSES>
+          <root url="jar://$USER_HOME$/.cache/savant/javax/inject/javax.inject/1.0.0/javax.inject-1.0.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/beust/jcommander/1.82.0/jcommander-1.82.0-src.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/javax/inject/javax.inject/1.0.0/javax.inject-1.0.0-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/webjars/jquery/3.6.1/jquery-3.6.1.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/org/aopalliance/aopalliance/1.0.0/aopalliance-1.0.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/webjars/jquery/3.6.1/jquery-3.6.1-src.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/org/aopalliance/aopalliance/1.0.0/aopalliance-1.0.0-src.jar!/" />
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="TEST">
+      <library>
+        <CLASSES>
+          <root url="jar://$USER_HOME$/.cache/savant/com/google/guava/guava/25.1.0-android/guava-25.1.0-android.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES>
+          <root url="jar://$USER_HOME$/.cache/savant/com/google/guava/guava/25.1.0-android/guava-25.1.0-android-src.jar!/" />
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="TEST">
+      <library>
+        <CLASSES>
+          <root url="jar://$USER_HOME$/.cache/savant/org/checkerframework/checker-compat-qual/2.0.0/checker-compat-qual-2.0.0.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES>
+          <root url="jar://$USER_HOME$/.cache/savant/org/checkerframework/checker-compat-qual/2.0.0/checker-compat-qual-2.0.0-src.jar!/" />
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="TEST">
+      <library>
+        <CLASSES>
+          <root url="jar://$USER_HOME$/.cache/savant/com/google/j2objc/j2objc-annotations/1.1.0/j2objc-annotations-1.1.0.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES>
+          <root url="jar://$USER_HOME$/.cache/savant/com/google/j2objc/j2objc-annotations/1.1.0/j2objc-annotations-1.1.0-src.jar!/" />
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="TEST">
+      <library>
+        <CLASSES>
+          <root url="jar://$USER_HOME$/.cache/savant/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES>
+          <root url="jar://$USER_HOME$/.cache/savant/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2-src.jar!/" />
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="TEST">
+      <library>
+        <CLASSES>
+          <root url="jar://$USER_HOME$/.cache/savant/com/google/errorprone/error_prone_annotations/2.1.3/error_prone_annotations-2.1.3.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES>
+          <root url="jar://$USER_HOME$/.cache/savant/com/google/errorprone/error_prone_annotations/2.1.3/error_prone_annotations-2.1.3-src.jar!/" />
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="TEST">
+      <library>
+        <CLASSES>
+          <root url="jar://$USER_HOME$/.cache/savant/org/codehaus/mojo/animal-sniffer-annotations/1.14.0/animal-sniffer-annotations-1.14.0.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES>
+          <root url="jar://$USER_HOME$/.cache/savant/org/codehaus/mojo/animal-sniffer-annotations/1.14.0/animal-sniffer-annotations-1.14.0-src.jar!/" />
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="TEST">
+      <library>
+        <CLASSES>
+          <root url="jar://$USER_HOME$/.cache/savant/org/yaml/snakeyaml/1.21.0/snakeyaml-1.21.0.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES>
+          <root url="jar://$USER_HOME$/.cache/savant/org/yaml/snakeyaml/1.21.0/snakeyaml-1.21.0-src.jar!/" />
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="TEST">
+      <library>
+        <CLASSES>
+          <root url="jar://$USER_HOME$/.cache/savant/org/junit/junit/4.12.0/junit-4.12.0.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES>
+          <root url="jar://$USER_HOME$/.cache/savant/org/junit/junit/4.12.0/junit-4.12.0-src.jar!/" />
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="TEST">
+      <library>
+        <CLASSES>
+          <root url="jar://$USER_HOME$/.cache/savant/org/hamcrest/hamcrest-core/1.3.0/hamcrest-core-1.3.0.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES>
+          <root url="jar://$USER_HOME$/.cache/savant/org/hamcrest/hamcrest-core/1.3.0/hamcrest-core-1.3.0-src.jar!/" />
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="TEST">
+      <library>
+        <CLASSES>
+          <root url="jar://$USER_HOME$/.cache/savant/org/apache/ant/ant/1.10.3/ant-1.10.3.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES>
+          <root url="jar://$USER_HOME$/.cache/savant/org/apache/ant/ant/1.10.3/ant-1.10.3-src.jar!/" />
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="TEST">
+      <library>
+        <CLASSES>
+          <root url="jar://$USER_HOME$/.cache/savant/org/apache/ant/ant-launcher/1.10.3/ant-launcher-1.10.3.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES>
+          <root url="jar://$USER_HOME$/.cache/savant/org/apache/ant/ant-launcher/1.10.3/ant-launcher-1.10.3-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>

--- a/jackson5.iml
+++ b/jackson5.iml
@@ -15,33 +15,33 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.15.4/jackson-databind-2.15.4.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.21.1/jackson-databind-2.21.1.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.15.4/jackson-databind-2.15.4-sources.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.21.1/jackson-databind-2.21.1-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.15.4/jackson-annotations-2.15.4.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.21/jackson-annotations-2.21.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.15.4/jackson-annotations-2.15.4-sources.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.21/jackson-annotations-2.21-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.15.4/jackson-core-2.15.4.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.21.1/jackson-core-2.21.1.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.15.4/jackson-core-2.15.4-sources.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.21.1/jackson-core-2.21.1-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.21.1</version>
+      <version>2.21.4</version>
       <type>jar</type>
       <scope>compile</scope>
       <optional>false</optional>
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.21.1</version>
+      <version>2.21.4</version>
       <type>jar</type>
       <scope>compile</scope>
       <optional>false</optional>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.inversoft</groupId>
   <artifactId>jackson5</artifactId>
-  <version>3.0.1</version>
+  <version>3.1.0</version>
   <packaging>jar</packaging>
 
   <name>Inversoft Jackson Serializers and Deserializers</name>
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.15.4</version>
+      <version>2.21.1</version>
       <type>jar</type>
       <scope>compile</scope>
       <optional>false</optional>
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.15.4</version>
+      <version>2.21.1</version>
       <type>jar</type>
       <scope>compile</scope>
       <optional>false</optional>
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.15.4</version>
+      <version>2.21.0</version>
       <type>jar</type>
       <scope>compile</scope>
       <optional>false</optional>

--- a/src/main/java/com/inversoft/json/ZonedDateTimeDeserializer.java
+++ b/src/main/java/com/inversoft/json/ZonedDateTimeDeserializer.java
@@ -51,14 +51,10 @@ public class ZonedDateTimeDeserializer extends StdScalarDeserializer<ZonedDateTi
       try {
         value = Long.parseLong(str);
       } catch (NumberFormatException e) {
-        ctxt.reportWrongTokenException(handledType(),
-            JsonToken.VALUE_NUMBER_INT,
-            "Parseable to long");
+        ctxt.handleUnexpectedToken(handledType(), jp);
       }
     } else {
-      ctxt.reportWrongTokenException(handledType(),
-          JsonToken.VALUE_NUMBER_INT,
-          "Parseable to long");
+      ctxt.handleUnexpectedToken(handledType(), jp);
     }
 
     return ZonedDateTime.ofInstant(Instant.ofEpochMilli(value), ZoneOffset.UTC);

--- a/src/main/java/com/inversoft/json/ZonedDateTimeDeserializer.java
+++ b/src/main/java/com/inversoft/json/ZonedDateTimeDeserializer.java
@@ -52,12 +52,12 @@ public class ZonedDateTimeDeserializer extends StdScalarDeserializer<ZonedDateTi
         value = Long.parseLong(str);
       } catch (NumberFormatException e) {
         ctxt.reportWrongTokenException(ZonedDateTime.class,
-            t,
+            JsonToken.VALUE_NUMBER_INT,
             "Parseable to long");
       }
     } else {
       ctxt.reportWrongTokenException(ZonedDateTime.class,
-          t,
+          JsonToken.VALUE_NUMBER_INT,
           "Parseable to long");
     }
 

--- a/src/main/java/com/inversoft/json/ZonedDateTimeDeserializer.java
+++ b/src/main/java/com/inversoft/json/ZonedDateTimeDeserializer.java
@@ -51,10 +51,14 @@ public class ZonedDateTimeDeserializer extends StdScalarDeserializer<ZonedDateTi
       try {
         value = Long.parseLong(str);
       } catch (NumberFormatException e) {
-        ctxt.reportInputMismatch(ZonedDateTime.class, "stuff");
+        ctxt.reportWrongTokenException(ZonedDateTime.class,
+            t,
+            "Parseable to long");
       }
     } else {
-      ctxt.reportInputMismatch(ZonedDateTime.class, "stuff");
+      ctxt.reportWrongTokenException(ZonedDateTime.class,
+          t,
+          "Parseable to long");
     }
 
     return ZonedDateTime.ofInstant(Instant.ofEpochMilli(value), ZoneOffset.UTC);

--- a/src/main/java/com/inversoft/json/ZonedDateTimeDeserializer.java
+++ b/src/main/java/com/inversoft/json/ZonedDateTimeDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2021, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2015-2026, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ public class ZonedDateTimeDeserializer extends StdScalarDeserializer<ZonedDateTi
   @Override
   public ZonedDateTime deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException, JsonProcessingException {
     JsonToken t = jp.getCurrentToken();
-    long value;
+    long value = 0;
     if (t == JsonToken.VALUE_NUMBER_INT || t == JsonToken.VALUE_NUMBER_FLOAT) {
       value = jp.getLongValue();
     } else if (t == JsonToken.VALUE_STRING) {
@@ -51,10 +51,10 @@ public class ZonedDateTimeDeserializer extends StdScalarDeserializer<ZonedDateTi
       try {
         value = Long.parseLong(str);
       } catch (NumberFormatException e) {
-        throw ctxt.mappingException(handledType());
+        ctxt.reportInputMismatch(ZonedDateTime.class, "stuff");
       }
     } else {
-      throw ctxt.mappingException(handledType());
+      ctxt.reportInputMismatch(ZonedDateTime.class, "stuff");
     }
 
     return ZonedDateTime.ofInstant(Instant.ofEpochMilli(value), ZoneOffset.UTC);

--- a/src/main/java/com/inversoft/json/ZonedDateTimeDeserializer.java
+++ b/src/main/java/com/inversoft/json/ZonedDateTimeDeserializer.java
@@ -51,12 +51,12 @@ public class ZonedDateTimeDeserializer extends StdScalarDeserializer<ZonedDateTi
       try {
         value = Long.parseLong(str);
       } catch (NumberFormatException e) {
-        ctxt.reportWrongTokenException(ZonedDateTime.class,
+        ctxt.reportWrongTokenException(handledType(),
             JsonToken.VALUE_NUMBER_INT,
             "Parseable to long");
       }
     } else {
-      ctxt.reportWrongTokenException(ZonedDateTime.class,
+      ctxt.reportWrongTokenException(handledType(),
           JsonToken.VALUE_NUMBER_INT,
           "Parseable to long");
     }

--- a/src/test/java/com/inversoft/json/ZonedDateTimeDeserializerTest.java
+++ b/src/test/java/com/inversoft/json/ZonedDateTimeDeserializerTest.java
@@ -99,6 +99,20 @@ public class ZonedDateTimeDeserializerTest {
   }
 
   @Test
+  public void parses_correctly_long() throws JsonProcessingException {
+    // Use case: 1234.0 milliseconds past epoch, parses OK
+
+    // arrange
+
+    // act
+    ZonedDateTime result = mapper.readValue("1772569622544", ZonedDateTime.class);
+
+    // assert
+    assertEquals(result,
+        ZonedDateTime.parse("2026-03-03T20:27:02.544Z"));
+  }
+
+  @Test
   public void parses_correctly_string() throws JsonProcessingException {
     // Use case: "1234" milliseconds past epoch, parses OK
 

--- a/src/test/java/com/inversoft/json/ZonedDateTimeDeserializerTest.java
+++ b/src/test/java/com/inversoft/json/ZonedDateTimeDeserializerTest.java
@@ -64,10 +64,8 @@ public class ZonedDateTimeDeserializerTest {
       mapper.readValue("\"1970-01-01T00:00:01.234Z\"", ZonedDateTime.class);
       fail("Expected exception");
     } catch (JsonMappingException e) {
-      assertEquals(e.getMessage(),
-          "Unexpected token (VALUE_STRING), expected VALUE_NUMBER_INT: Parseable to long\n" +
-          " at [Source: (String)\"\"1970-01-01T00:00:01.234Z\"\"; line: 1, column: 1]");
-    }
+      assertEquals(e.getOriginalMessage(),
+          "Unexpected token (VALUE_STRING), expected VALUE_NUMBER_INT: Parseable to long");
   }
 
   @Test

--- a/src/test/java/com/inversoft/json/ZonedDateTimeDeserializerTest.java
+++ b/src/test/java/com/inversoft/json/ZonedDateTimeDeserializerTest.java
@@ -50,7 +50,7 @@ public class ZonedDateTimeDeserializerTest {
       fail("Expected exception");
     } catch (JsonMappingException e) {
       assertEquals(e.getOriginalMessage(),
-          "Unexpected token (VALUE_TRUE), expected VALUE_NUMBER_INT: Parseable to long");
+          "Cannot deserialize value of type `long` from Boolean value (token `JsonToken.VALUE_TRUE`)");
     }
   }
 
@@ -66,7 +66,7 @@ public class ZonedDateTimeDeserializerTest {
       fail("Expected exception");
     } catch (JsonMappingException e) {
       assertEquals(e.getOriginalMessage(),
-          "Unexpected token (VALUE_STRING), expected VALUE_NUMBER_INT: Parseable to long");
+          "Cannot deserialize value of type `long` from String value (token `JsonToken.VALUE_STRING`)");
     }
   }
 

--- a/src/test/java/com/inversoft/json/ZonedDateTimeDeserializerTest.java
+++ b/src/test/java/com/inversoft/json/ZonedDateTimeDeserializerTest.java
@@ -50,7 +50,7 @@ public class ZonedDateTimeDeserializerTest {
       fail("Expected exception");
     } catch (JsonMappingException e) {
       assertEquals(e.getMessage(),
-          "Unexpected token (VALUE_TRUE), expected VALUE_TRUE: Parseable to long\n" +
+          "Unexpected token (VALUE_TRUE), expected VALUE_NUMBER_INT: Parseable to long\n" +
           " at [Source: (String)\"true\"; line: 1, column: 1]");
     }
   }
@@ -67,7 +67,7 @@ public class ZonedDateTimeDeserializerTest {
       fail("Expected exception");
     } catch (JsonMappingException e) {
       assertEquals(e.getMessage(),
-          "Unexpected token (VALUE_STRING), expected VALUE_STRING: Parseable to long\n" +
+          "Unexpected token (VALUE_STRING), expected VALUE_NUMBER_INT: Parseable to long\n" +
           " at [Source: (String)\"\"1970-01-01T00:00:01.234Z\"\"; line: 1, column: 1]");
     }
   }

--- a/src/test/java/com/inversoft/json/ZonedDateTimeDeserializerTest.java
+++ b/src/test/java/com/inversoft/json/ZonedDateTimeDeserializerTest.java
@@ -49,10 +49,8 @@ public class ZonedDateTimeDeserializerTest {
       mapper.readValue("true", ZonedDateTime.class);
       fail("Expected exception");
     } catch (JsonMappingException e) {
-      assertEquals(e.getMessage(),
-          "Unexpected token (VALUE_TRUE), expected VALUE_NUMBER_INT: Parseable to long\n" +
-          " at [Source: (String)\"true\"; line: 1, column: 1]");
-    }
+      assertEquals(e.getOriginalMessage(),
+          "Unexpected token (VALUE_TRUE), expected VALUE_NUMBER_INT: Parseable to long");
   }
 
   @Test

--- a/src/test/java/com/inversoft/json/ZonedDateTimeDeserializerTest.java
+++ b/src/test/java/com/inversoft/json/ZonedDateTimeDeserializerTest.java
@@ -100,7 +100,7 @@ public class ZonedDateTimeDeserializerTest {
 
   @Test
   public void parses_correctly_long() throws JsonProcessingException {
-    // Use case: 1234.0 milliseconds past epoch, parses OK
+    // Use case: 1772569622544 milliseconds past epoch, parses OK
 
     // arrange
 

--- a/src/test/java/com/inversoft/json/ZonedDateTimeDeserializerTest.java
+++ b/src/test/java/com/inversoft/json/ZonedDateTimeDeserializerTest.java
@@ -39,6 +39,23 @@ public class ZonedDateTimeDeserializerTest {
   }
 
   @Test
+  public void parse_error_boolean() throws JsonProcessingException {
+    // Use case: A boolean (not string/int/float/long) value is passed, which is not valid
+
+    // arrange
+
+    // act
+    try {
+      mapper.readValue("true", ZonedDateTime.class);
+      fail("Expected exception");
+    } catch (JsonMappingException e) {
+      assertEquals(e.getMessage(),
+          "Unexpected token (VALUE_TRUE), expected VALUE_TRUE: Parseable to long\n" +
+          " at [Source: (String)\"true\"; line: 1, column: 1]");
+    }
+  }
+
+  @Test
   public void parse_error_string() throws JsonProcessingException {
     // Use case: A full ISO date time value is passed, which is not valid
 
@@ -50,7 +67,7 @@ public class ZonedDateTimeDeserializerTest {
       fail("Expected exception");
     } catch (JsonMappingException e) {
       assertEquals(e.getMessage(),
-          "stuff\n" +
+          "Unexpected token (VALUE_STRING), expected VALUE_STRING: Parseable to long\n" +
           " at [Source: (String)\"\"1970-01-01T00:00:01.234Z\"\"; line: 1, column: 1]");
     }
   }

--- a/src/test/java/com/inversoft/json/ZonedDateTimeDeserializerTest.java
+++ b/src/test/java/com/inversoft/json/ZonedDateTimeDeserializerTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026, Inversoft Inc., All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package com.inversoft.json;
+
+import java.time.ZonedDateTime;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class ZonedDateTimeDeserializerTest {
+  private ObjectMapper mapper;
+
+  @BeforeMethod
+  public void beforeMethod() {
+    mapper = new ObjectMapper();
+    mapper.registerModule(new JacksonModule());
+    mapper.enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION.mappedFeature());
+  }
+
+  @Test
+  public void parse_error_string() throws JsonProcessingException {
+    // Use case: A full ISO date time value is passed, which is not valid
+
+    // arrange
+
+    // act
+    try {
+      mapper.readValue("\"1970-01-01T00:00:01.234Z\"", ZonedDateTime.class);
+      fail("Expected exception");
+    } catch (JsonMappingException e) {
+      assertEquals(e.getMessage(),
+          "stuff\n" +
+          " at [Source: (String)\"\"1970-01-01T00:00:01.234Z\"\"; line: 1, column: 1]");
+    }
+  }
+
+  @Test
+  public void parses_correctly_float() throws JsonProcessingException {
+    // Use case: 1234.0 milliseconds past epoch, parses OK
+
+    // arrange
+
+    // act
+    ZonedDateTime result = mapper.readValue("1234.0", ZonedDateTime.class);
+
+    // assert
+    assertEquals(result,
+        ZonedDateTime.parse("1970-01-01T00:00:01.234Z"));
+  }
+
+  @Test
+  public void parses_correctly_int() throws JsonProcessingException {
+    // Use case: 1234 milliseconds past epoch, parses OK
+
+    // arrange
+
+    // act
+    ZonedDateTime result = mapper.readValue("1234", ZonedDateTime.class);
+
+    // assert
+    assertEquals(result,
+        ZonedDateTime.parse("1970-01-01T00:00:01.234Z"));
+  }
+
+  @Test
+  public void parses_correctly_string() throws JsonProcessingException {
+    // Use case: "1234" milliseconds past epoch, parses OK
+
+    // arrange
+
+    // act
+    ZonedDateTime result = mapper.readValue("\"1234\"", ZonedDateTime.class);
+
+    // assert
+    assertEquals(result,
+        ZonedDateTime.parse("1970-01-01T00:00:01.234Z"));
+  }
+}

--- a/src/test/java/com/inversoft/json/ZonedDateTimeDeserializerTest.java
+++ b/src/test/java/com/inversoft/json/ZonedDateTimeDeserializerTest.java
@@ -51,6 +51,7 @@ public class ZonedDateTimeDeserializerTest {
     } catch (JsonMappingException e) {
       assertEquals(e.getOriginalMessage(),
           "Unexpected token (VALUE_TRUE), expected VALUE_NUMBER_INT: Parseable to long");
+    }
   }
 
   @Test
@@ -66,6 +67,7 @@ public class ZonedDateTimeDeserializerTest {
     } catch (JsonMappingException e) {
       assertEquals(e.getOriginalMessage(),
           "Unexpected token (VALUE_STRING), expected VALUE_NUMBER_INT: Parseable to long");
+    }
   }
 
   @Test


### PR DESCRIPTION
### Problems:

1. Modern Jackson versions (2.21.1 in our case) no longer have the `mappingException` method that `ZonedDateTimeDeserializer` uses in error cases. It appears to have been removed in https://github.com/FasterXML/jackson-databind/commit/c1cfdd3712345f09030ec5451c2c8abf107fbd7f - 2.16.0
2. No tests existed for this class.
3. Savant 2.2.0/IML out of date and no CI/CD.

### Solutions:
1. Write tests that cover the known cases, including an error.
2. Bump the Jackson dependency version up, which causes the test to fail like real apps can fail.
3. Fix using code noted in self review.
4. Savant IML updates (see 37209586ef5905f56d15f468ad5224385a96448e) - also added basic CI/CD.

### Author Notes:

Previously, you'd get an HTTP 500 using the Prime MVC tech stack with this library, if for example, you supplied a string value not parseable to a long for a zoneddatetime field.

Now, you can get an HTTP 400 response like this:

```json
{
  "fieldErrors": {
    "users.insertInstant": [
      {
        "code": "[invalidJSON]",
        "message": "Invalid JSON in the request body. The property was [users.insertInstant]. The error was [Possible conversion error]. The detailed exception was [Cannot deserialize value of type `long` from String value (token `JsonToken.VALUE_STRING`)\n at [Source: (io.fusionauth.http.server.io.HTTPInputStream); line: 5, column: 24] (through reference chain: io.fusionauth.domain.api.user.ImportRequest[\"users\"]->java.util.ArrayList[0]->io.fusionauth.domain.User[\"insertInstant\"])]."
      }
    ]
  },
  "generalErrors": []
}
```